### PR TITLE
「ん」で終わってもリダイレクトしないように変更

### DIFF
--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -38,11 +38,13 @@ class WordsController < ApplicationController
 
       ShiritoriEvaluationJob.perform_later(room.words.where(room_participant: room_participant).last)
 
+      # ★修正箇所：即座にリダイレクトせず、ゲームオーバー状態を設定するだけ
       render turbo_stream: [
         turbo_stream.update('flash-messages', partial: 'layouts/flash', locals: { message: result[:message], type: 'danger' }),
+        turbo_stream.append('word-history', partial: 'words/word', locals: { word: room.words.where(room_participant: room_participant).last }),
         turbo_stream.append_all('body', view_context.javascript_tag(<<-JS.squish)),
           document.dispatchEvent(new CustomEvent('game:over', {
-            detail: { redirectUrl: '#{result_room_path(room)}' }
+            detail: { message: '#{result[:message]}' }
           }))
         JS
       ]

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -4,7 +4,7 @@
   <div class="card text-center mb-3">
     <div class="card-body">
       <h3 class="card-title">
-        プレイヤー: 
+        プレイヤー:
         <% if guest_user? %>
           <%= cookies.encrypted[:guest_name] %>
         <% else %>
@@ -32,7 +32,7 @@
   </div>
 
   <div id="game-over-message" class="alert alert-info text-center fs-4 d-none">
-    ゲーム終了！
+    ゲーム終了！時間終了まで待機してください...
   </div>
 
   <div id="flash-messages">
@@ -42,3 +42,44 @@
   <%= render "rooms/word_form", room: @room %>
 
 </div>
+
+<script>
+// ゲームオーバー状態を管理
+let gameOver = false;
+
+// ゲームオーバーイベントを監聴
+document.addEventListener('game:over', function(event) {
+  gameOver = true;
+
+  // 入力フィールドを無効化
+  const wordForm = document.getElementById('word_form');
+  if (wordForm) {
+    const inputs = wordForm.querySelectorAll('input, button');
+    inputs.forEach(input => {
+      input.disabled = true;
+      if (input.type === 'text') {
+        input.placeholder = 'ゲームオーバー - 時間終了まで待機中...';
+        input.style.backgroundColor = '#f0f0f0';
+      }
+    });
+  }
+
+  // ゲームオーバーメッセージを表示
+  const gameOverMessage = document.getElementById('game-over-message');
+  if (gameOverMessage) {
+    gameOverMessage.classList.remove('d-none');
+  }
+
+  // ★重要：リダイレクト処理は削除（タイマー終了まで待機）
+  console.log('ゲームオーバー状態に設定されました');
+});
+
+// 既存のStimulusコントローラーがある場合は、そちらでも制御
+// フォーム送信時にもゲームオーバーチェックを追加
+document.addEventListener('submit', function(event) {
+  if (gameOver && event.target.closest('#word_form')) {
+    event.preventDefault();
+    return false;
+  }
+});
+</script>


### PR DESCRIPTION
1. WordsController（words_controller.rb）:
・when :game_over の部分で、redirectUrl: '#{result_room_path(room)}' を削除
・代わりに message: '#{result[:message]}' だけを送信
・単語履歴にも追加するようにした

2. show.html.erb:
・JavaScriptで game:over イベントを監聴
・ゲームオーバー時は入力フィールドを無効化するだけ
・メッセージ表示を「時間終了まで待機」に変更
・重要: リダイレクト処理を削除