### PR TITLE
AIの回答待ちのロジック・プロンプトの変更

### DIFF
--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -12,7 +12,8 @@ class WordsController < ApplicationController
 
     case result[:status]
     when :success
-      score = 100 + (new_word.length * 10)
+      # ===== ここで基礎点を計算しています =====
+      score = 100 + (new_word.length**2) * 10 # 新しい計算式
       @word_record = room.words.create(
         body: new_word,
         score: score,
@@ -32,7 +33,8 @@ class WordsController < ApplicationController
       ]
 
     when :game_over
-      score = 100 + (new_word.length * 10)
+      # ===== ここでも基礎点を計算しています =====
+      score = 100 + (new_word.length**2) * 10 # 新しい計算式
       word_record = room.words.create!(
         body: new_word,
         score: score,

--- a/app/services/shiritori_chain_evaluation_service.rb
+++ b/app/services/shiritori_chain_evaluation_service.rb
@@ -5,27 +5,34 @@ class ShiritoriChainEvaluationService
   end
 
   def evaluate_and_save
-    # 既に評価済み、または前の単語が存在しない場合は処理しない
     return if @current_word.chain_bonus_score.present? || @previous_word.nil?
 
     prompt = <<-PROMPT
-日本のしりとりで、前の単語「#{@previous_word.body}」に続く単語として「#{@current_word.body}」が使われました。
-この2つの単語の関連性を評価し、0から15点の整数でボーナススコアを付けてください。
-評価基準は、意味的な繋がり、連想の自然さ、意外性や面白さです。
-結果は「スコア: [点数]\\n理由: [評価理由]」の形式で返してください。
-例:
-スコア: 12
-理由: 「りんご」の次に「ゴリラ」と続いており、動物という繋がりで自然な連想です。
+# 概要
+あなたは、しりとりゲームの単語の連鎖を評価するAIです。
+「#{@previous_word.body}」→「#{@current_word.body}」の連鎖を分析し、以下の2つを生成してください。
+
+1.  **評価点:** -10点から10点の間（整数）で評価します。テーマ性、物語性、意外な関連性などを基準とします。
+2.  **評価理由:** なぜその点数になったのか、面白くて納得できる詳細な説明を「ですます調」で記述してください。
+
+評価理由において、スコア自体は絶対に表記しないでください。(例:〇〇点と評価しました)
+
+# 出力形式
+「評価点: [点数]」「理由: [評価理由]」の形式を必ず守ってください。
     PROMPT
 
     begin
       response_text = GeminiCraft.generate_content(prompt)
-      
-      score = response_text.match(/スコア:\s*(\d+)/)&.captures&.first&.to_i
-      comment = response_text.match(/理由:\s*(.+)/)&.captures&.first
 
-      if score && comment
-        @current_word.update!(chain_bonus_score: score, chain_bonus_comment: comment)
+      base_score = response_text.match(/評価点:\s*(\-?\d+)/)&.captures&.first&.to_i
+      comment = response_text.match(/理由:\s*(.+)/m)&.captures&.first
+
+      if base_score && comment
+        word_jitter = (@previous_word.body + @current_word.body).bytes.sum % 999 - 499
+
+        final_score = (base_score * 500) + word_jitter
+
+        @current_word.update!(chain_bonus_score: final_score, chain_bonus_comment: comment)
       end
     rescue => e
       Rails.logger.error "AI連鎖評価中にエラーが発生しました。単語: '#{@current_word.body}', エラー: #{e.message}"

--- a/app/views/rooms/result.html.erb
+++ b/app/views/rooms/result.html.erb
@@ -1,6 +1,12 @@
 <div class="container py-5 text-center">
   <h1 class="mb-4">ゲーム結果</h1>
 
+  <% if @evaluation_timed_out %>
+    <div class="alert alert-warning mb-4">
+      AIによる評価が時間内に完了しませんでした。一部のスコアがまだ計算中です。しばらくしてからページを更新してください。
+    </div>
+  <% end %>
+
   <% if @winner %>
     <div class="alert alert-success mb-4">
       <h2>🏆 1位: <%= @winner.username %> 🏆</h2>
@@ -107,7 +113,7 @@
                             </div>
                             <div class="text-end ms-3" style="min-width: 140px;">
                               <% if word.score.to_i > 0 %>
-                                 <span class="badge bg-secondary rounded-pill">基礎: <%= word.score %>点</span>
+                                <span class="badge bg-secondary rounded-pill">基礎: <%= word.score %>点</span>
                                 <% if word.ai_score.present? %>
                                   <span class="badge bg-info rounded-pill">AI: <%= word.ai_score %>点</span>
                                 <% else %>
@@ -119,7 +125,7 @@
                                 <% end %>
                                 
                                 <% if word.chain_bonus_score.present? %>
-                                  <span class="badge bg-success rounded-pill mt-1">連鎖: +<%= word.chain_bonus_score %>点</span>
+                                  <span class="badge bg-success rounded-pill mt-1">連鎖: <%= word.chain_bonus_score %>点</span>
                                 <% end %>
                               <% else %>
                                 <span class="badge bg-light text-muted rounded-pill">開始単語</span>


### PR DESCRIPTION
より面白いゲームバランスを実現するため、スコア計算のロジックを以下のように改善しました。

基礎点の調整

長い単語の価値が少し高まるように、基礎点の計算式を変更しました。

 AI評価の完了を待ってから結果を表示するよう変更。

AI評価の改善

課題: AIの評価点が特定の数値に偏り、スコアが単調になる問題がありました。

解決策: AIには「-10〜10点」の評価をさせ、サーバー側でその評価を1000倍し、さらに単語ごとに決まっている固定値を加算する方式に変更しました。

これにより、AI評価の意図を尊重しつつ、単語が違えば必ずスコアも変わるようになり、スコアの重複がなくなりました。

イースターエッグの追加

特定の単語を入力すると、スペシャルスコアが加算されるようにしました。